### PR TITLE
Removed need to call Activator.CreateInstance for each call to Execute or ExecuteNonQuery

### DIFF
--- a/CassandraSharp/CQLPoco/CQLPocoExtensions.cs
+++ b/CassandraSharp/CQLPoco/CQLPocoExtensions.cs
@@ -32,21 +32,34 @@ namespace CassandraSharp.CQLPoco
             return factory;
         }
 
+        private static IDataMapperFactory GetFactory<T>(T dataSource)
+        {
+            //IDataMapperFactory factory = new DataMapperFactory(type, dataSource);
+            IDataMapperFactory factory = new DynamicDataMapperFactory<T>(dataSource);
+            return factory;
+        }
+
         public static Task<IEnumerable<T>> Execute<T>(this ICluster cluster, string cql, ConsistencyLevel cl = ConsistencyLevel.QUORUM)
         {
-            IDataMapperFactory factory = GetFactory(typeof(T), null);
+            IDataMapperFactory factory = GetFactory<T>(default(T));
             return CQLCommandHelpers.Query<T>(cluster, cql, cl, factory);
         }
 
-        public static Task<IEnumerable<T>> Execute<T>(this IPreparedQuery preparedQuery, object dataSource, ConsistencyLevel cl = ConsistencyLevel.QUORUM)
+        public static Task<IEnumerable<T>> Execute<T>(this IPreparedQuery preparedQuery, T dataSource, ConsistencyLevel cl = ConsistencyLevel.QUORUM)
         {
-            IDataMapperFactory factory = GetFactory(typeof(T), dataSource);
+            IDataMapperFactory factory = GetFactory<T>(dataSource);
             return preparedQuery.Execute(cl, factory).ContinueWith(res => res.Result.Cast<T>());
         }
 
         public static Task<int> ExecuteNonQuery(this IPreparedQuery preparedQuery, object dataSource, ConsistencyLevel cl = ConsistencyLevel.QUORUM)
         {
             IDataMapperFactory factory = GetFactory(typeof(Unit), dataSource);
+            return preparedQuery.Execute(cl, factory).ContinueWith(res => res.Result.Count());
+        }
+        
+        public static Task<int> ExecuteNonQuery<T>(this IPreparedQuery preparedQuery, T dataSource, ConsistencyLevel cl = ConsistencyLevel.QUORUM)
+        {
+            IDataMapperFactory factory = GetFactory<T>(dataSource);
             return preparedQuery.Execute(cl, factory).ContinueWith(res => res.Result.Count());
         }
     }

--- a/CassandraSharp/CQLPoco/DynamicDataMapperFactory.cs
+++ b/CassandraSharp/CQLPoco/DynamicDataMapperFactory.cs
@@ -20,7 +20,7 @@ namespace CassandraSharp.CQLPoco
 
     internal class DynamicDataMapperFactory : IDataMapperFactory
     {
-        private readonly Type _type;
+        private Type _type;
 
         public DynamicDataMapperFactory(Type type, object dataSource)
         {
@@ -28,6 +28,26 @@ namespace CassandraSharp.CQLPoco
             if (null != dataSource)
             {
                 DataSource = DynamicDataSourceFactory.Create(dataSource);
+            }
+        }
+
+        public IDataSource DataSource { get; private set; }
+
+        public IInstanceBuilder CreateBuilder()
+        {
+            return DynamicInstanceBuilderFactory.Create(_type);
+        }
+    }
+
+    internal class DynamicDataMapperFactory<T> : IDataMapperFactory
+    {
+        private static readonly Type _type = typeof(T);
+
+        public DynamicDataMapperFactory(T dataSource)
+        {
+            if (null != dataSource)
+            {
+                DataSource = new DynamicDataSource<T> { Datasource = dataSource };
             }
         }
 

--- a/CassandraSharp/CQLPoco/DynamicDataSource.cs
+++ b/CassandraSharp/CQLPoco/DynamicDataSource.cs
@@ -24,6 +24,16 @@ namespace CassandraSharp.CQLPoco
 
         private T _dataSource;
 
+        internal T Datasource
+        {
+            get { return _dataSource; }
+            set { _dataSource = value; }
+        }
+
+        internal DynamicDataSource()
+        { 
+        }
+
         public DynamicDataSource(T dataSource)
         {
             _dataSource = dataSource;


### PR DESCRIPTION
Added DynamicDataMapperFactory<T>, which circumvents DynamicDataSourceFactory (and thereby a call to Activator.CreateInstance) for each Execute or ExecuteNonQuery call. Because we already have the T parameter, there is no need to execute DynamicDataSourceFactory.Create, we can simply call "new DynamicDataSource<T> { Datasource = dataSource };" instead. None of the object visibilities have been altered and the change is extremely localized.
