### PR TITLE
New endpoint strategies & start of murmur3 hashing support

### DIFF
--- a/CassandraSharp.Interfaces/QueryHint.cs
+++ b/CassandraSharp.Interfaces/QueryHint.cs
@@ -15,6 +15,8 @@
 
 namespace CassandraSharp
 {
+    using System.Numerics;
+
     public class QueryHint
     {
         public QueryHint()
@@ -22,7 +24,7 @@ namespace CassandraSharp
             ReplicationFactor = 1;
         }
 
-        public object Key { get; set; }
+        public BigInteger Key { get; set; }
 
         public int ReplicationFactor { get; set; }
     }

--- a/CassandraSharp/CQLBinaryProtocol/Command.cs
+++ b/CassandraSharp/CQLBinaryProtocol/Command.cs
@@ -36,13 +36,18 @@ namespace CassandraSharp.CQLBinaryProtocol
 
         public ICqlQuery<T> Execute<T>(string cql, object dataSource)
         {
+            return Execute<T>(cql, dataSource, null);
+        }
+
+        public ICqlQuery<T> Execute<T>(string cql, object dataSource, QueryHint hint)
+        {
             if (null != dataSource)
             {
                 throw new ArgumentException("Binary protocol v2 is not implemented");
             }
 
             IDataMapper factoryOut = _factoryOut.Create<T>();
-            IConnection connection = _cluster.GetConnection();
+            IConnection connection = _cluster.GetConnection(hint);
             ICqlQuery<T> query = new CqlQuery<T>(connection, cql, factoryOut);
             return query;
         }

--- a/CassandraSharp/CQLBinaryProtocol/MurmurHash.cs
+++ b/CassandraSharp/CQLBinaryProtocol/MurmurHash.cs
@@ -1,0 +1,165 @@
+﻿
+namespace CassandraSharp.CQLBinaryProtocol
+{
+    /// <summary>
+    ///   This is a very fast, non-cryptographic hash suitable for general hash-based
+    ///   lookup. See http://murmurhash.googlepages.com/ for more details.
+    ///  
+    ///   hash3_x64_128() is MurmurHash 3.0.
+    /// </summary>
+    /// <remarks>
+    ///   Copied from https://github.com/datastax/csharp-driver/blob/master/Cassandra/MurmurHash.cs
+    /// </remarks>
+    public class MurmurHash
+    {
+        private static long GetBlock(byte[] key, int offset, int index)
+        {
+            int i_8 = index << 3;
+            int blockOffset = offset + i_8;
+            return ((long)key[blockOffset + 0] & 0xff) + (((long)key[blockOffset + 1] & 0xff) << 8) +
+                   (((long)key[blockOffset + 2] & 0xff) << 16) + (((long)key[blockOffset + 3] & 0xff) << 24) +
+                   (((long)key[blockOffset + 4] & 0xff) << 32) + (((long)key[blockOffset + 5] & 0xff) << 40) +
+                   (((long)key[blockOffset + 6] & 0xff) << 48) + (((long)key[blockOffset + 7] & 0xff) << 56);
+        }
+
+        private static long Rotl64(long v, int n)
+        {
+            return ((v << n) | ((long)((ulong)v >> (64 - n))));
+        }
+
+        private static long Fmix(long k)
+        {
+            k ^= (long)((ulong)k >> 33);
+            k *= -0xAE502812AA7333;
+            k ^= (long)((ulong)k >> 33);
+            k *= -0x3B314601E57A13AD;
+            k ^= (long)((ulong)k >> 33);
+
+            return k;
+        }
+
+        public static long[] Hash3_x64_128(byte[] key, int offset, int length, long seed)
+        {
+            int nblocks = length >> 4; // Process as 128-bit blocks.
+
+            long h1 = seed;
+            long h2 = seed;
+
+            const long c1 = -0x783C846EEEBDAC2B;
+            const long c2 = 0x4cf5ad432745937fL;
+
+            //----------
+            // body
+
+            for (int i = 0; i < nblocks; i++)
+            {
+                long k1 = GetBlock(key, offset, i * 2 + 0);
+                long k2 = GetBlock(key, offset, i * 2 + 1);
+
+                k1 *= c1;
+                k1 = Rotl64(k1, 31);
+                k1 *= c2;
+                h1 ^= k1;
+
+                h1 = Rotl64(h1, 27);
+                h1 += h2;
+                h1 = h1 * 5 + 0x52dce729;
+
+                k2 *= c2;
+                k2 = Rotl64(k2, 33);
+                k2 *= c1;
+                h2 ^= k2;
+
+                h2 = Rotl64(h2, 31);
+                h2 += h1;
+                h2 = h2 * 5 + 0x38495ab5;
+            }
+
+            //----------
+            // tail
+
+            // Advance offset to the unprocessed tail of the data.
+            offset += nblocks * 16;
+
+            {
+                long k1 = 0;
+                long k2 = 0;
+
+                switch (length & 15)
+                {
+                    case 15:
+                        k2 ^= ((long)key[offset + 14]) << 48;
+                        goto case 14;
+                    case 14:
+                        k2 ^= ((long)key[offset + 13]) << 40;
+                        goto case 13;
+                    case 13:
+                        k2 ^= ((long)key[offset + 12]) << 32;
+                        goto case 12;
+                    case 12:
+                        k2 ^= ((long)key[offset + 11]) << 24;
+                        goto case 11;
+                    case 11:
+                        k2 ^= ((long)key[offset + 10]) << 16;
+                        goto case 10;
+                    case 10:
+                        k2 ^= ((long)key[offset + 9]) << 8;
+                        goto case 9;
+                    case 9:
+                        k2 ^= ((long)key[offset + 8]) << 0;
+                        k2 *= c2;
+                        k2 = Rotl64(k2, 33);
+                        k2 *= c1;
+                        h2 ^= k2;
+                        goto case 8;
+
+                    case 8:
+                        k1 ^= ((long)key[offset + 7]) << 56;
+                        goto case 7;
+                    case 7:
+                        k1 ^= ((long)key[offset + 6]) << 48;
+                        goto case 6;
+                    case 6:
+                        k1 ^= ((long)key[offset + 5]) << 40;
+                        goto case 5;
+                    case 5:
+                        k1 ^= ((long)key[offset + 4]) << 32;
+                        goto case 4;
+                    case 4:
+                        k1 ^= ((long)key[offset + 3]) << 24;
+                        goto case 3;
+                    case 3:
+                        k1 ^= ((long)key[offset + 2]) << 16;
+                        goto case 2;
+                    case 2:
+                        k1 ^= ((long)key[offset + 1]) << 8;
+                        goto case 1;
+                    case 1:
+                        k1 ^= (key[offset]);
+                        k1 *= c1;
+                        k1 = Rotl64(k1, 31);
+                        k1 *= c2;
+                        h1 ^= k1;
+                        break;
+                }
+                ;
+            }
+            //----------
+            // finalization
+
+            h1 ^= length;
+            h2 ^= length;
+
+            h1 += h2;
+            h2 += h1;
+
+            h1 = Fmix(h1);
+            h2 = Fmix(h2);
+
+            h1 += h2;
+            h2 += h1;
+
+            return (new[] { h1, h2 });
+        }
+    }
+}

--- a/CassandraSharp/CQLBinaryProtocol/ValueSerialization.cs
+++ b/CassandraSharp/CQLBinaryProtocol/ValueSerialization.cs
@@ -21,6 +21,7 @@ namespace CassandraSharp.CQLBinaryProtocol
     using System.IO;
     using System.Net;
     using System.Text;
+    using System.Linq;
     using CassandraSharp.Extensibility;
     using CassandraSharp.Utils;
     using CassandraSharp.Utils.Stream;
@@ -282,6 +283,69 @@ namespace CassandraSharp.CQLBinaryProtocol
             }
 
             throw new ArgumentException("Unsupported type");
+        }
+
+
+
+        /// <summary>
+        /// Gets murmur hash based on a provided value.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static long getMurmur3Hash(ColumnType type, Object value)
+        {
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            byte[] partitionKey = Serialize(type, value);
+            return MurmurHash.Hash3_x64_128(partitionKey, 0, partitionKey.Length, 0)[0];
+        }
+
+        /// <summary>
+        /// Gets murmur hash based on the provided values. Use this when composite partition keys are used
+        /// </summary>
+        /// <param name="types"></param>
+        /// <param name="values">The values must be given in the same order as the partition key is defined.</param>
+        /// <returns></returns>
+        public static long getCompositeMurmur3Hash(ColumnType[] types, Object[] values)
+        {
+            if (types == null)
+                throw new ArgumentNullException("types");
+
+            if (values == null)
+                throw new ArgumentNullException("values");
+
+
+            if (types.Length != values.Length)
+                throw new ArgumentException("types and values are not of equal length");
+
+            var rawValues = new byte[types.Length][];
+            for (int i = 0; i < types.Length; i++)
+            {
+                rawValues[i] = Serialize(types[i], values[i]);
+            }
+
+            int length = types.Length * 3 + rawValues.Sum(val => val.Length);
+            using (var stream = new MemoryStream(length))
+            {
+                foreach (var rawValue in rawValues)
+                {
+                    //write length of composite key part as short
+                    var len = (short)rawValue.Length;
+                    stream.WriteByte((byte)(len >> 8));
+                    stream.WriteByte((byte)(len));
+
+                    //write value
+                    stream.Write(rawValue, 0, len);
+
+                    //write terminator byte
+                    stream.WriteByte(0);
+                }
+
+                byte[] partitionKey = stream.ToArray();
+                return MurmurHash.Hash3_x64_128(partitionKey, 0, partitionKey.Length, 0)[0];
+            }
         }
     }
 }

--- a/CassandraSharp/EndpointStrategy/Factory.cs
+++ b/CassandraSharp/EndpointStrategy/Factory.cs
@@ -27,6 +27,8 @@ namespace CassandraSharp.EndpointStrategy
                     {"Random", typeof(RandomEndpointStrategy)},
                     {"Nearest", typeof(NearestEndpointStrategy)},
                     {"TokenAware", typeof(TokenAwareStrategy)},
+                    {"RoundRobin", typeof(RoundRobinEndpointStrategy)},
+                    {"TokenRing", typeof(TokenRingEndpointStrategy)},
             };
 
         public IDictionary<string, Type> Definition

--- a/CassandraSharp/EndpointStrategy/RoundRobinEndpointStrategy.cs
+++ b/CassandraSharp/EndpointStrategy/RoundRobinEndpointStrategy.cs
@@ -1,0 +1,110 @@
+﻿// cassandra-sharp - high performance .NET driver for Apache Cassandra
+// Copyright (c) 2011-2013 Pierre Chalamet
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CassandraSharp.EndpointStrategy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Numerics;
+    using System.Text;
+    using System.Threading.Tasks;
+    using CassandraSharp;
+    using CassandraSharp.Extensibility;
+
+    /// <summary>
+    /// Will loop through nodes to perfectly evenly spread load.
+    /// </summary>
+    internal sealed class RoundRobinEndpointStrategy : IEndpointStrategy
+    {
+        private readonly List<IPAddress> _bannedEndpoints;
+        private readonly List<IPAddress> _healthyEndpoints;
+        private readonly object _lock = new object();
+        private int _nextCandidate;
+
+        
+        public RoundRobinEndpointStrategy(IEnumerable<IPAddress> endpoints)
+        {
+            _healthyEndpoints = new List<IPAddress>(endpoints);
+            _bannedEndpoints = new List<IPAddress>();
+            _nextCandidate = 0;
+        }
+
+
+
+        public void Ban(IPAddress endpoint)
+        {
+            lock (_lock)
+            {
+                if (_healthyEndpoints.Remove(endpoint))
+                {
+                    _bannedEndpoints.Add(endpoint);
+                }
+            }
+        }
+
+
+
+        public void Permit(IPAddress endpoint)
+        {
+            lock (_lock)
+            {
+                if (_bannedEndpoints.Remove(endpoint))
+                {
+                    _healthyEndpoints.Add(endpoint);
+                }
+            }
+        }
+
+
+
+        public IPAddress Pick(QueryHint hint)
+        {
+            lock (_lock)
+            {
+                IPAddress endpoint = null;
+                if (0 < _healthyEndpoints.Count)
+                {
+                    endpoint = _healthyEndpoints[_nextCandidate++];
+                    _nextCandidate %= _healthyEndpoints.Count;
+                }
+
+                return endpoint;
+            }
+        }
+
+
+        public void Update(NotificationKind kind, Peer peer)
+        {
+            lock (_lock)
+            {
+                IPAddress endpoint = peer.RpcAddress;
+                switch (kind)
+                {
+                    case NotificationKind.Add:
+                    case NotificationKind.Update:
+                        if (!_healthyEndpoints.Contains(endpoint) && !_bannedEndpoints.Contains(endpoint))
+                            _healthyEndpoints.Add(endpoint);
+                        break;
+                    case NotificationKind.Remove:
+                        if (_healthyEndpoints.Contains(endpoint))
+                            _healthyEndpoints.Remove(endpoint);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/CassandraSharp/EndpointStrategy/TokenRingEndpointStrategy.cs
+++ b/CassandraSharp/EndpointStrategy/TokenRingEndpointStrategy.cs
@@ -1,0 +1,260 @@
+﻿// cassandra-sharp - high performance .NET driver for Apache Cassandra
+// Copyright (c) 2011-2013 Pierre Chalamet
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CassandraSharp.EndpointStrategy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Numerics;
+    using System.Text;
+    using System.Threading.Tasks;
+    using CassandraSharp;
+    using CassandraSharp.Extensibility;
+
+    /// <summary>
+    /// Will pick a node by it's token to choose the coordinator node by the row key of the query.
+    /// Requires QueryHints.
+    /// Where QueryHint's are ommitted, will fallback to RoundRobin
+    /// </summary>
+    internal sealed class TokenRingEndpointStrategy : IEndpointStrategy
+    {
+        private readonly List<IPAddress> _healthyEndpoints;
+        private readonly object _lock = new object();
+        private int _roundRobinPointer;
+        private readonly TokenRing _ring;
+
+
+
+        public TokenRingEndpointStrategy(IEnumerable<IPAddress> endpoints)
+        {
+            _healthyEndpoints = new List<IPAddress>(endpoints);
+            _roundRobinPointer = 0;
+            _ring = new TokenRing();
+        }
+
+
+
+        public void Ban(IPAddress endpoint)
+        {
+            lock (_lock)
+            {
+                if (_healthyEndpoints.Remove(endpoint))
+                {
+                    _ring.banNode(endpoint);
+                }
+            }
+        }
+
+
+
+        public void Permit(IPAddress endpoint)
+        {
+            lock (_lock)
+            {
+                _healthyEndpoints.Add(endpoint);
+                _ring.permitNode(endpoint);
+            }
+        }
+
+
+
+        public IPAddress Pick(QueryHint hint)
+        {
+            IPAddress endpoint = null;
+            if (0 < _healthyEndpoints.Count)
+            {
+                if (hint != null && _ring.ringSize() > 0)
+                {
+                    //Attempt to binary search for key in token ring
+                    lock (_lock)
+                    {
+                        endpoint = _ring.findReplica(hint.Key);
+                    }
+                }
+                else
+                {
+                    //fallback to round robin when no hint supplied
+                    lock (_lock)
+                    {
+                        endpoint = _healthyEndpoints[_roundRobinPointer++];
+                        _roundRobinPointer %= _healthyEndpoints.Count;
+                    }
+                }
+            }
+
+            return endpoint;
+        }
+
+
+
+        public void Update(NotificationKind kind, Peer peer)
+        {
+            lock (_lock)
+            {
+                IPAddress endpoint = peer.RpcAddress;
+                switch (kind)
+                {
+                    case NotificationKind.Add:
+                        if (!_healthyEndpoints.Contains(endpoint))
+                        {
+                            _healthyEndpoints.Add(endpoint);
+                            _ring.addOrUpdateNode(peer);
+                        }
+                        break;
+                    case NotificationKind.Update:
+                        _ring.addOrUpdateNode(peer);
+                        break;
+                    case NotificationKind.Remove:
+                        if (_healthyEndpoints.Contains(endpoint))
+                        {
+                            _healthyEndpoints.Remove(endpoint);
+                            _ring.removeNode(endpoint);
+                        }
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Represents spread of tokens around nodes
+        /// </summary>
+        internal sealed class TokenRing
+        {
+            private SortedDictionary<BigInteger, IPAddress> _permittedTokenRing;
+            private SortedDictionary<BigInteger, IPAddress> _bannedTokenRing;
+            private List<BigInteger> _tokenCache; //sorted list of tokens: for efficiency of binary search
+
+            internal TokenRing()
+            {
+                _permittedTokenRing = new SortedDictionary<BigInteger, IPAddress>();
+                _bannedTokenRing = new SortedDictionary<BigInteger, IPAddress>();
+                _tokenCache = new List<BigInteger>();
+            }
+
+            /// <summary>
+            /// Use binary search to find first token that is smaller than key
+            /// </summary>
+            /// <param name="key">Row key as BigInteger hash</param>
+            /// <returns>IPAddress of node that owns the token</returns>
+            internal IPAddress findReplica(BigInteger key)
+            {
+                int i = _tokenCache.BinarySearch(key);
+
+                if (i < 0)
+                {
+                    i = ~i - 1;
+                    if (i >= _permittedTokenRing.Keys.Count || i < 0)
+                        i = 0;
+                }
+
+                return _permittedTokenRing[_permittedTokenRing.Keys.ElementAt(i)];
+            }
+
+            /// <summary>
+            /// Get number of permitted tokens
+            /// </summary>
+            /// <remarks>
+            /// Should be number of nodes * vnodes per node
+            /// </remarks>
+            /// <returns>Number of permitted tokens in ring</returns>
+            internal int ringSize()
+            {
+                return _permittedTokenRing.Count;
+            }
+
+            /// <summary>
+            /// Adds a new range of tokens to the permitted token ring
+            /// </summary>
+            /// <param name="peer">IPAddress and token range of the discovered node</param>
+            internal void addOrUpdateNode(Peer peer)
+            {
+                foreach (BigInteger token in peer.Tokens)
+                {
+                    //remove if updating
+                    _permittedTokenRing.Remove(token);
+                    _bannedTokenRing.Remove(token);
+
+                    _permittedTokenRing.Add(token, peer.RpcAddress);
+
+                    _tokenCache = _permittedTokenRing.Keys.ToList();
+                }
+            }
+
+            /// <summary>
+            /// Move keys from one dictionary to another based on their value's
+            /// </summary>
+            /// <typeparam name="T">Type of key</typeparam>
+            /// <typeparam name="V">Type of value</typeparam>
+            /// <param name="src">Source Dictionary</param>
+            /// <param name="dest">Destination Dictionary</param>
+            /// <param name="val">Value to move by</param>
+            private void moveOnValue<T, V>(IDictionary<T, V> src, IDictionary<T, V> dest, V val)
+            {
+                var bannedTokens = src.Where(keyVal => keyVal.Value.Equals(val));
+                foreach (var token in bannedTokens)
+                {
+                    dest.Add(token.Key, token.Value);
+                    src.Remove(token.Key);
+                }
+            }
+
+            /// <summary>
+            /// Remove keys from a dictionary based on their value's
+            /// </summary>
+            /// <typeparam name="T">Type of key</typeparam>
+            /// <typeparam name="V">Type of value</typeparam>
+            /// <param name="src">Source Dictionary</param>
+            /// <param name="val">Value to remove by</param>
+            private void removeOnValue<T, V>(IDictionary<T, V> src, V val)
+            {
+                foreach(var keyVal in src.Where(keyVal => keyVal.Value.Equals(val)).ToArray())
+                    src.Remove(keyVal.Key);
+            }
+
+            /// <summary>
+            /// Ban a node's tokens
+            /// </summary>
+            /// <param name="endpoint">Node to ban</param>
+            internal void banNode(IPAddress endpoint)
+            {
+                moveOnValue(_permittedTokenRing, _bannedTokenRing, endpoint);
+                _tokenCache = _permittedTokenRing.Keys.ToList();
+            }
+
+            /// <summary>
+            /// Permit a node's tokens
+            /// </summary>
+            /// <param name="endpoint">Node to permit</param>
+            internal void permitNode(IPAddress endpoint)
+            {
+                moveOnValue(_bannedTokenRing, _permittedTokenRing, endpoint);
+                _tokenCache = _permittedTokenRing.Keys.ToList();
+            }
+
+            /// <summary>
+            /// Completely remove a node's tokens from the ring
+            /// </summary>
+            /// <param name="endpoint">Node to remove</param>
+            internal void removeNode(IPAddress endpoint)
+            {
+                removeOnValue(_permittedTokenRing, endpoint);
+                removeOnValue(_bannedTokenRing, endpoint);
+                _tokenCache = _permittedTokenRing.Keys.ToList();
+            }
+        }
+    }
+}


### PR DESCRIPTION
From Issue #56. A small extension that I've been using recently.

Idea is to create QueryHint's with Murmur3 hashes in the key field and to provide them to TokenRingEndpointStrategy with Command.Execute

I've had to change key object in QueryHint to BigInteger. Not sure if this is an issue?

RoundRobin yields better query spreading on small numbers of nodes than Random.

Some of this needs to re-thought/improved. Probably need to either move or create an interface to the new Murmur3 hashing functions in ValueSerialization, preferably in QueryHint and I'm not sure whether you'd want to chnage ICqlCommand.
