### PR TITLE
Property File Snitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cassandra-sharp-interface-version.cs
 bin/
 obj/
 Resharper.DotSettings
+.nuget/packages.config

--- a/CassandraSharp.Interfaces/Config/EndpointsConfig.cs
+++ b/CassandraSharp.Interfaces/Config/EndpointsConfig.cs
@@ -32,6 +32,9 @@ namespace CassandraSharp.Config
         [XmlAttribute("snitch")]
         public string Snitch { get; set; }
 
+        [XmlAttribute("primarydc")]
+        public string PrimaryDataCenter { get; set; }
+
         [XmlAttribute("strategy")]
         public string Strategy { get; set; }
 

--- a/CassandraSharp.Interfaces/Extensibility/IEndpointSnitch.cs
+++ b/CassandraSharp.Interfaces/Extensibility/IEndpointSnitch.cs
@@ -24,8 +24,12 @@ namespace CassandraSharp.Extensibility
 
         string GetDatacenter(IPAddress endpoint);
 
+        bool IsPrimaryDatacenter(IPAddress endpoint);
+
         List<IPAddress> GetSortedListByProximity(IPAddress address, IEnumerable<IPAddress> unsortedAddress);
 
         int CompareEndpoints(IPAddress address, IPAddress a1, IPAddress a2);
+
+        void Update(NotificationKind kind, Peer peer);
     }
 }

--- a/CassandraSharp.Interfaces/Extensibility/Peer.cs
+++ b/CassandraSharp.Interfaces/Extensibility/Peer.cs
@@ -15,13 +15,83 @@
 
 namespace CassandraSharp.Extensibility
 {
+    using System;
     using System.Net;
     using System.Numerics;
+    using System.Linq;
 
     public sealed class Peer
     {
+        public Peer()
+        {
+        }
+
+
+        public Peer(IPAddress rpcAddress, string datacenter, string rack, BigInteger[] tokens)
+            : this()
+        {
+            this.RpcAddress = rpcAddress;
+            this.Datacenter = datacenter;
+            this.Rack = rack;
+            this.Tokens = tokens;
+        }
+
         public IPAddress RpcAddress { get; internal set; }
 
+        public string Datacenter { get; internal set; }
+
+        public string Rack { get; internal set; }
+
         public BigInteger[] Tokens { get; internal set; }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            var item = obj as Peer;
+            if ((object)item == null)
+                return false;
+
+            return item.RpcAddress.Equals(this.RpcAddress)
+                && (item.Tokens.Length == this.Tokens.Length && item.Tokens.Intersect(this.Tokens).Count() == item.Tokens.Length)
+                && item.Datacenter.Equals(this.Datacenter, StringComparison.InvariantCulture)
+                && item.Rack.Equals(this.Rack, StringComparison.InvariantCulture);
+        }
+
+        public override int GetHashCode()
+        {
+            //use built in anonymous hashing
+            return new
+            {
+                this.RpcAddress,
+                Datacentre = this.Datacenter,
+                this.Rack,
+                this.Tokens
+            }.GetHashCode();
+        }
+
+        /// <summary>
+        /// Gets a proximity score where:
+        /// 0 = Same rack & dc
+        /// 1 = Same dc
+        /// 2 = Different dc
+        /// </summary>
+        /// <param name="peer"></param>
+        /// <returns></returns>
+        public int GetProximity(Peer peer)
+        {
+            if (this.Datacenter.Equals(peer.Datacenter, StringComparison.InvariantCulture)
+                && this.Rack.Equals(peer.Rack, StringComparison.InvariantCulture))
+                return 0; //same rack in same dc
+
+            if (this.Datacenter == peer.Datacenter)
+                //same dc differnt rack
+                return 1;
+            else
+                //different dc, rack irrelevent
+                return 2;
+        }
     }
 }

--- a/CassandraSharp/EndpointStrategy/Factory.cs
+++ b/CassandraSharp/EndpointStrategy/Factory.cs
@@ -27,6 +27,7 @@ namespace CassandraSharp.EndpointStrategy
                     {"Random", typeof(RandomEndpointStrategy)},
                     {"Nearest", typeof(NearestEndpointStrategy)},
                     {"RoundRobin", typeof(RoundRobinEndpointStrategy)},
+                    {"RoundRobinFailover", typeof(RoundRobinFailoverEndpointStrategy)},
                     {"TokenRing", typeof(TokenRingEndpointStrategy)},
             };
 

--- a/CassandraSharp/EndpointStrategy/RoundRobinEndpointStrategy.cs
+++ b/CassandraSharp/EndpointStrategy/RoundRobinEndpointStrategy.cs
@@ -23,15 +23,15 @@ namespace CassandraSharp.EndpointStrategy
     /// <summary>
     ///     Will loop through nodes to perfectly evenly spread load.
     /// </summary>
-    internal sealed class RoundRobinEndpointStrategy : IEndpointStrategy
+    internal class RoundRobinEndpointStrategy : IEndpointStrategy
     {
-        private readonly List<IPAddress> _bannedEndpoints;
+        protected List<IPAddress> _bannedEndpoints;
 
-        private readonly List<IPAddress> _healthyEndpoints;
+        protected List<IPAddress> _healthyEndpoints;
 
-        private readonly object _lock = new object();
+        protected readonly object _lock = new object();
 
-        private int _nextCandidate;
+        protected int _nextCandidate;
 
         public RoundRobinEndpointStrategy(IEnumerable<IPAddress> endpoints)
         {
@@ -40,7 +40,7 @@ namespace CassandraSharp.EndpointStrategy
             _nextCandidate = 0;
         }
 
-        public void Ban(IPAddress endpoint)
+        virtual public void Ban(IPAddress endpoint)
         {
             lock (_lock)
             {
@@ -51,7 +51,7 @@ namespace CassandraSharp.EndpointStrategy
             }
         }
 
-        public void Permit(IPAddress endpoint)
+        virtual public void Permit(IPAddress endpoint)
         {
             lock (_lock)
             {
@@ -77,7 +77,7 @@ namespace CassandraSharp.EndpointStrategy
             }
         }
 
-        public void Update(NotificationKind kind, Peer peer)
+        virtual public void Update(NotificationKind kind, Peer peer)
         {
             lock (_lock)
             {
@@ -95,6 +95,10 @@ namespace CassandraSharp.EndpointStrategy
                         if (_healthyEndpoints.Contains(endpoint))
                         {
                             _healthyEndpoints.Remove(endpoint);
+                        }
+                        else if (_bannedEndpoints.Contains(endpoint))
+                        {
+                            _bannedEndpoints.Remove(endpoint);
                         }
                         break;
                 }

--- a/CassandraSharp/EndpointStrategy/RoundRobinFailoverEndpointStrategy.cs
+++ b/CassandraSharp/EndpointStrategy/RoundRobinFailoverEndpointStrategy.cs
@@ -1,0 +1,151 @@
+﻿
+
+namespace CassandraSharp.EndpointStrategy
+{
+    using System.Collections.Generic;
+    using System.Net;
+    using CassandraSharp.Extensibility;
+
+    /// <summary>
+    ///     Use RoundRobin stratgey on primary dc (must be set in config in EndPointsConfig)
+    ///     until all nodes are unavailable then failover to all other dc's.
+    /// </summary>
+    internal sealed class RoundRobinFailoverEndpointStrategy : RoundRobinEndpointStrategy
+    {
+        private List<IPAddress> _failoverHealthyEndpoints;
+        private List<IPAddress> _failoverBannedEndpoints;
+        private bool _inFailover;
+        private IEndpointSnitch _snitch;
+        private bool _firstUpdateCalled;
+
+        public RoundRobinFailoverEndpointStrategy(IEnumerable<IPAddress> endpoints, IEndpointSnitch snitch)
+            : base(endpoints)
+        {
+            _failoverHealthyEndpoints = new List<IPAddress>();
+            _failoverBannedEndpoints = new List<IPAddress>();
+            _inFailover = false;
+            _snitch = snitch;
+            _firstUpdateCalled = false;
+        }
+
+        /// <summary>
+        /// Swaps current nodes used by base class with the failover nodes managed by this class
+        /// </summary>
+        private void failover()
+        {
+            lock (_lock)
+            {
+                var tmp = _healthyEndpoints;
+                _healthyEndpoints = _failoverHealthyEndpoints;
+                _failoverHealthyEndpoints = tmp;
+
+                tmp = _bannedEndpoints;
+                _bannedEndpoints = _failoverBannedEndpoints;
+                _failoverBannedEndpoints = tmp;
+
+                _nextCandidate = 0;
+                _inFailover = !_inFailover;
+            }
+        }
+
+        public override void Ban(IPAddress endpoint)
+        {
+            if (_inFailover == _snitch.IsPrimaryDatacenter(endpoint))
+            {
+                //failover & primarydc or not failover and not primarydc then failover nodes affected
+                lock (_lock)
+                {
+                    if (_failoverHealthyEndpoints.Remove(endpoint))
+                    {
+                        _failoverBannedEndpoints.Add(endpoint);
+                    }
+                }
+            }
+            else
+            {
+                base.Ban(endpoint);
+
+                if (_healthyEndpoints.Count == 0)
+                    failover();
+            }
+
+            
+        }
+
+        public override void Permit(IPAddress endpoint)
+        {
+            if (_inFailover == _snitch.IsPrimaryDatacenter(endpoint))
+            {
+                //failover & primarydc or not failover and not primarydc then failover nodes affected
+                lock (_lock)
+                {
+                    if (_failoverBannedEndpoints.Remove(endpoint))
+                    {
+                        _failoverHealthyEndpoints.Add(endpoint);
+
+                        //in failover and a new primary dc node has been added
+                        if (_inFailover && _snitch.IsPrimaryDatacenter(endpoint))
+                            failover(); //revert back to primary dc
+                    }
+                }
+            }
+            else
+            {
+                base.Permit(endpoint);
+            }
+        }
+
+        public override void Update(NotificationKind kind, Peer peer)
+        {
+            //remove temporary list of all endpoitns created by base constructor
+            if (!_firstUpdateCalled)
+            {
+                _healthyEndpoints = new List<IPAddress>();
+                _firstUpdateCalled = true;
+            }
+
+            IPAddress endpoint = peer.RpcAddress;
+            bool isPrimaryDc = _snitch.IsPrimaryDatacenter(endpoint);
+            if (_inFailover == isPrimaryDc)
+            {
+                //failover & primarydc or not failover and not primarydc then failover nodes affected
+                lock (_lock)
+                {
+                    switch (kind)
+                    {
+                        case NotificationKind.Add:
+                        case NotificationKind.Update:
+                            if (!_failoverHealthyEndpoints.Contains(endpoint)
+                            && !_failoverBannedEndpoints.Contains(endpoint))
+                            {
+                                _failoverHealthyEndpoints.Add(endpoint);
+
+                                //possibility new node added to revert existing failover
+                                if (_inFailover && isPrimaryDc)
+                                    failover();
+                            }
+                            break;
+                        case NotificationKind.Remove:
+                            if (_failoverHealthyEndpoints.Contains(endpoint))
+                            {
+                                _failoverHealthyEndpoints.Remove(endpoint);
+                            }
+                            else if (_failoverBannedEndpoints.Contains(endpoint))
+                            {
+                                _failoverBannedEndpoints.Remove(endpoint);
+                            }
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                base.Update(kind, peer);
+
+                if (kind == NotificationKind.Remove && _healthyEndpoints.Count == 0)
+                    failover();
+            }
+        }
+
+    }
+}

--- a/CassandraSharp/Snitch/DiscoverySnitch.cs
+++ b/CassandraSharp/Snitch/DiscoverySnitch.cs
@@ -1,0 +1,159 @@
+﻿
+
+namespace CassandraSharp.Snitch
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using CassandraSharp.Extensibility;
+
+    /// <summary>
+    ///     Takes all network topology information from the discovery servive's ISnitch.Update event notification
+    /// </summary>
+    internal sealed class DiscoverySnitch : IEndpointSnitch
+    {
+        private readonly Dictionary<IPAddress, Peer> _networkTopology;
+        private readonly string _primaryDatacenter;
+        private readonly object _lock = new object();
+
+        public DiscoverySnitch(string primaryDatacenter)
+        {
+            _networkTopology = new Dictionary<IPAddress, Peer>();
+            _primaryDatacenter = primaryDatacenter;
+        }
+
+
+        private Peer GetTopology(IPAddress endpoint)
+        {
+            try
+            {
+                return _networkTopology[endpoint];
+            }
+            catch
+            {
+                throw new SnitchNotReadyException(endpoint.ToString());
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <exception cref="SnitchNotReadyException">
+        /// When endpoint not initialised in the snitch's internal dictionary
+        /// This is only usually thrown by SystemPeersDiscoveryService depending on Endpoint Strategy
+        /// </exception>
+        /// <returns></returns>
+        public string GetRack(IPAddress endpoint)
+        {
+            return GetTopology(endpoint).Rack;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <exception cref="SnitchNotReadyException">
+        /// When endpoint not initialised in the snitch's internal dictionary
+        /// This is only usually thrown by SystemPeersDiscoveryService depending on Endpoint Strategy
+        /// </exception>
+        /// <returns></returns>
+        public string GetDatacenter(IPAddress endpoint)
+        {
+            return GetTopology(endpoint).Datacenter;
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <returns></returns>
+        public bool IsPrimaryDatacenter(IPAddress endpoint)
+        {
+            return GetDatacenter(endpoint).Equals(_primaryDatacenter, StringComparison.InvariantCulture);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="unsortedAddress"></param>
+        /// <exception cref="SnitchNotReadyException">
+        /// When endpoint not initialised in the snitch's internal dictionary
+        /// This is only usually thrown by SystemPeersDiscoveryService depending on Endpoint Strategy
+        /// </exception>
+        /// <returns></returns>
+        public List<IPAddress> GetSortedListByProximity(IPAddress address, IEnumerable<IPAddress> unsortedAddress)
+        {
+            var addressTopology = GetTopology(address);
+
+            return unsortedAddress
+                .OrderBy(ip => addressTopology.GetProximity(GetTopology(ip)))
+                .ToList();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="a1"></param>
+        /// <param name="a2"></param>
+        /// <exception cref="SnitchNotReadyException">
+        /// When endpoint not initialised in the snitch's internal dictionary
+        /// This is only usually thrown by SystemPeersDiscoveryService depending on Endpoint Strategy
+        /// </exception>
+        /// <returns></returns>
+        public int CompareEndpoints(IPAddress address, IPAddress a1, IPAddress a2)
+        {
+            var addressTopology = GetTopology(address);
+            int proximityA1 = addressTopology.GetProximity(GetTopology(a1));
+            int proximityA2 = addressTopology.GetProximity(GetTopology(a2));
+
+            if (proximityA1 == proximityA2)
+                return 0; //address is neither closer to a1 or a2
+            else if (proximityA1 < proximityA2)
+                return -1; //address is closer to a1
+            else
+                return 1; //address is closer to a2
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="kind"></param>
+        /// <param name="peer"></param>
+        public void Update(NotificationKind kind, Peer peer)
+        {
+            lock (_lock)
+            {
+                IPAddress endpoint = peer.RpcAddress;
+                switch (kind)
+                {
+                    case NotificationKind.Add:
+                    case NotificationKind.Update:
+                        if (_networkTopology.ContainsKey(endpoint))
+                            _networkTopology.Remove(endpoint);
+                        _networkTopology.Add(endpoint, peer);
+                        break;
+                    case NotificationKind.Remove:
+                        if (_networkTopology.ContainsKey(endpoint))
+                            _networkTopology.Remove(endpoint);
+                        break;
+                }
+            }
+        }
+
+        [Serializable]
+        public class SnitchNotReadyException : Exception
+        {
+            public SnitchNotReadyException() : base() { }
+            public SnitchNotReadyException(string message) : base(message) { }
+            public SnitchNotReadyException(string message, System.Exception inner) : base(message, inner) { }
+
+            protected SnitchNotReadyException(System.Runtime.Serialization.SerializationInfo info,
+                System.Runtime.Serialization.StreamingContext context) { }
+        }
+    }
+}

--- a/CassandraSharp/Snitch/Factory.cs
+++ b/CassandraSharp/Snitch/Factory.cs
@@ -23,9 +23,10 @@ namespace CassandraSharp.Snitch
     {
         private static readonly IDictionary<string, Type> _def = new Dictionary<string, Type>
             {
-                    {"Default", typeof(RackInferringSnitch)},
+                    {"Default", typeof(DiscoverySnitch)},
                     {"Simple", typeof(SimpleSnitch)},
                     {"RackInferring", typeof(RackInferringSnitch)},
+                    {"Discovery", typeof(DiscoverySnitch)},
             };
 
         public IDictionary<string, Type> Definition

--- a/CassandraSharp/Snitch/RackInferringSnitch.cs
+++ b/CassandraSharp/Snitch/RackInferringSnitch.cs
@@ -36,6 +36,11 @@ namespace CassandraSharp.Snitch
             return dc;
         }
 
+        public bool IsPrimaryDatacenter(IPAddress endpoint)
+        {
+            return true;
+        }
+
         public List<IPAddress> GetSortedListByProximity(IPAddress address, IEnumerable<IPAddress> unsortedAddress)
         {
             List<IPAddress> sortedAddress = new List<IPAddress>(unsortedAddress);
@@ -86,6 +91,13 @@ namespace CassandraSharp.Snitch
             }
 
             return 0;
+        }
+
+
+        public void Update(NotificationKind kind, Peer peer)
+        {
+            //nothing to do
+            return;
         }
     }
 }

--- a/CassandraSharp/Snitch/SimpleSnitch.cs
+++ b/CassandraSharp/Snitch/SimpleSnitch.cs
@@ -31,6 +31,11 @@ namespace CassandraSharp.Snitch
             return "datacenter1";
         }
 
+        public bool IsPrimaryDatacenter(IPAddress endpoint)
+        {
+            return true;
+        }
+
         public List<IPAddress> GetSortedListByProximity(IPAddress address, IEnumerable<IPAddress> unsortedAddress)
         {
             return new List<IPAddress>(unsortedAddress);
@@ -39,6 +44,12 @@ namespace CassandraSharp.Snitch
         public int CompareEndpoints(IPAddress address, IPAddress a1, IPAddress a2)
         {
             return 0;
+        }
+
+        public void Update(NotificationKind kind, Peer peer)
+        {
+            //nothing to do
+            return;
         }
     }
 }

--- a/CassandraSharpUnitTests/EndpointStrategy/FactoryTest.cs
+++ b/CassandraSharpUnitTests/EndpointStrategy/FactoryTest.cs
@@ -96,5 +96,35 @@ namespace CassandraSharpUnitTests.EndpointStrategy
                                                                                                                                      new SimpleSnitch());
             Assert.IsTrue(endpointStrategy is RandomEndpointStrategy);
         }
+
+        [Test]
+        public void TestCreateRoundRobin()
+        {
+            IEndpointStrategy endpointStrategy = ServiceActivator<CassandraSharp.EndpointStrategy.Factory>.Create<IEndpointStrategy>("RoundRobin",
+                                                                                                                                     Enumerable.Empty<IPAddress>
+                                                                                                                                             (),
+                                                                                                                                     new SimpleSnitch());
+            Assert.IsTrue(endpointStrategy is RoundRobinEndpointStrategy);
+        }
+
+        [Test]
+        public void TestCreateRoundRobinFailover()
+        {
+            IEndpointStrategy endpointStrategy = ServiceActivator<CassandraSharp.EndpointStrategy.Factory>.Create<IEndpointStrategy>("RoundRobinFailover",
+                                                                                                                                     Enumerable.Empty<IPAddress>
+                                                                                                                                             (),
+                                                                                                                                     new SimpleSnitch());
+            Assert.IsTrue(endpointStrategy is RoundRobinFailoverEndpointStrategy);
+        }
+
+        [Test]
+        public void TestCreateTokenRing()
+        {
+            IEndpointStrategy endpointStrategy = ServiceActivator<CassandraSharp.EndpointStrategy.Factory>.Create<IEndpointStrategy>("TokenRing",
+                                                                                                                                     Enumerable.Empty<IPAddress>
+                                                                                                                                             (),
+                                                                                                                                     new SimpleSnitch());
+            Assert.IsTrue(endpointStrategy is TokenRingEndpointStrategy);
+        }
     }
 }

--- a/CassandraSharpUnitTests/EndpointStrategy/RoundRobinFailoverEndpointStrategyTest.cs
+++ b/CassandraSharpUnitTests/EndpointStrategy/RoundRobinFailoverEndpointStrategyTest.cs
@@ -1,0 +1,148 @@
+﻿
+
+namespace CassandraSharpUnitTests.EndpointStrategy
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using CassandraSharp.Extensibility;
+    using CassandraSharp.Utils;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class RoundRobinFailoverEndpointStrategyTest
+    {
+        IEndpointStrategy _endpointStrategy;
+        List<Peer> _endpoints;
+
+        [SetUp]
+        public void Init()
+        {
+            _endpoints = new List<Peer>()
+                {
+                    new Peer(IPAddress.Parse("192.168.1.1"), "DC1", "RAC1", null ),
+                    new Peer(IPAddress.Parse("192.168.1.2"), "DC1", "RAC1", null ),
+                    new Peer(IPAddress.Parse("192.168.2.1"), "DC1", "RAC2", null ),
+                    new Peer(IPAddress.Parse("192.168.2.2"), "DC1", "RAC2", null ),
+                    new Peer(IPAddress.Parse("172.168.1.1"), "DC2", "RAC1", null ),
+                    new Peer(IPAddress.Parse("172.168.1.2"), "DC2", "RAC1", null )
+                };
+            IEndpointSnitch snitch = ServiceActivator<CassandraSharp.Snitch.Factory>
+                .Create<IEndpointSnitch>("Discovery", "DC1");
+
+            _endpointStrategy = ServiceActivator<CassandraSharp.EndpointStrategy.Factory>
+                .Create<IEndpointStrategy>("RoundRobinFailover", _endpoints.Select(endpoint => endpoint.RpcAddress), snitch);
+
+            //simulate system.peers Discovery
+            foreach (var peer in _endpoints)
+            {
+                snitch.Update(NotificationKind.Update, peer);
+                _endpointStrategy.Update(NotificationKind.Update, peer);
+            }
+        }
+
+        [Test]
+        public void TestNormalOperation()
+        {
+            var dc1Endpoints = _endpoints.Where(peer => peer.Datacenter.Equals("DC1"));
+            var dc1Ips = dc1Endpoints.Select(peer => peer.RpcAddress);
+
+            IPAddress lastIp = IPAddress.Any;
+            for (int i = 0; i < 10; i++)
+            {
+                var picked = _endpointStrategy.Pick();
+
+                //ip is in dc1
+                Assert.IsTrue(dc1Ips.Contains(picked));
+                //different ip each time
+                Assert.AreNotEqual(lastIp, picked);
+
+                lastIp = picked;
+            }
+        }
+
+        [Test]
+        public void TestRemoveFailover()
+        {
+            var dc1Endpoints = _endpoints.Where(peer => peer.Datacenter.Equals("DC1"));
+            var dc1Ips = dc1Endpoints.Select(peer => peer.RpcAddress);
+
+            var dc2Endpoints = _endpoints.Where(peer => peer.Datacenter.Equals("DC2"));
+            var dc2Ips = dc2Endpoints.Select(peer => peer.RpcAddress);
+
+            dc1Endpoints.ToList().ForEach(peer => _endpointStrategy.Update(NotificationKind.Remove, peer));
+
+            IPAddress lastIp = IPAddress.Any;
+            for (int i = 0; i < 10; i++)
+            {
+                var picked = _endpointStrategy.Pick();
+
+                //ip is in dc1
+                Assert.IsTrue(dc2Ips.Contains(picked));
+                //different ip each time
+                Assert.AreNotEqual(lastIp, picked);
+
+                lastIp = picked;
+            }
+
+            //bring dc1 back
+            _endpointStrategy.Update(NotificationKind.Add, dc1Endpoints.First());
+            _endpointStrategy.Update(NotificationKind.Add, dc1Endpoints.Last());
+            lastIp = IPAddress.Any;
+            for (int i = 0; i < 10; i++)
+            {
+                var picked = _endpointStrategy.Pick();
+
+                //ip is in dc1
+                Assert.IsTrue(dc1Ips.Contains(picked));
+                //different ip each time
+                Assert.AreNotEqual(lastIp, picked);
+
+                lastIp = picked;
+            }
+        }
+
+
+
+        [Test]
+        public void TestBanFailover()
+        {
+            var dc1Endpoints = _endpoints.Where(peer => peer.Datacenter.Equals("DC1"));
+            var dc1Ips = dc1Endpoints.Select(peer => peer.RpcAddress);
+
+            var dc2Endpoints = _endpoints.Where(peer => peer.Datacenter.Equals("DC2"));
+            var dc2Ips = dc2Endpoints.Select(peer => peer.RpcAddress);
+
+            dc1Endpoints.ToList().ForEach(peer => _endpointStrategy.Ban(peer.RpcAddress));
+
+            IPAddress lastIp = IPAddress.Any;
+            for (int i = 0; i < 10; i++)
+            {
+                var picked = _endpointStrategy.Pick();
+
+                //ip is in dc1
+                Assert.IsTrue(dc2Ips.Contains(picked));
+                //different ip each time
+                Assert.AreNotEqual(lastIp, picked);
+
+                lastIp = picked;
+            }
+
+            //bring dc1 back
+            _endpointStrategy.Permit(dc1Ips.First());
+            _endpointStrategy.Permit(dc1Ips.Last());
+            lastIp = IPAddress.Any;
+            for (int i = 0; i < 10; i++)
+            {
+                var picked = _endpointStrategy.Pick();
+
+                //ip is in dc1
+                Assert.IsTrue(dc1Ips.Contains(picked));
+                //different ip each time
+                Assert.AreNotEqual(lastIp, picked);
+
+                lastIp = picked;
+            }
+        }
+    }
+}

--- a/CassandraSharpUnitTests/Snitch/DiscoverySnitchTest.cs
+++ b/CassandraSharpUnitTests/Snitch/DiscoverySnitchTest.cs
@@ -1,0 +1,102 @@
+﻿
+namespace CassandraSharpUnitTests.Snitch
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using CassandraSharp.Extensibility;
+    using CassandraSharp.Snitch;
+    using CassandraSharp.Utils;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class DiscoverySnitchTest
+    {
+        private IEndpointSnitch _snitch;
+        private List<Peer> _endpoints;
+
+        [SetUp]
+        public void Init()
+        {
+            //must be ordered by proximity to first element to pass TestSortedByProximity()
+            _endpoints = new List<Peer>()
+                {
+                    new Peer(IPAddress.Parse("192.168.1.1"), "DC1", "RAC1", null ),
+                    new Peer(IPAddress.Parse("192.168.1.2"), "DC1", "RAC1", null ),
+                    new Peer(IPAddress.Parse("192.168.2.1"), "DC1", "RAC2", null ),
+                    new Peer(IPAddress.Parse("192.168.2.2"), "DC1", "RAC2", null ),
+                    new Peer(IPAddress.Parse("172.168.1.1"), "DC2", "RAC1", null ),
+                    new Peer(IPAddress.Parse("172.168.1.2"), "DC2", "RAC1", null )
+                };
+            _snitch = ServiceActivator<Factory>.Create<IEndpointSnitch>("Discovery");
+            _endpoints.ForEach(peer => _snitch.Update(NotificationKind.Update, peer));
+        }
+
+        [Test]
+        public void TestDatacenter()
+        {
+            string adressDatacenter = _snitch.GetDatacenter(_endpoints[0].RpcAddress);
+            string a1Datacenter = _snitch.GetDatacenter(_endpoints[2].RpcAddress);
+            string a2Datacenter = _snitch.GetDatacenter(_endpoints[4].RpcAddress);
+
+            Assert.AreEqual(adressDatacenter, a1Datacenter);
+            Assert.AreNotEqual(adressDatacenter, a2Datacenter);
+        }
+
+
+        [Test]
+        public void TestNearestEndpoint()
+        {
+            IPAddress address = _endpoints[1].RpcAddress;
+            IPAddress a1 = _endpoints[5].RpcAddress;
+            IPAddress a2 = _endpoints[3].RpcAddress;
+
+            // a2 is nearest of address
+            int res = _snitch.CompareEndpoints(address, a1, a2);
+            Assert.AreEqual(1, res);
+
+            // same distance
+            res = _snitch.CompareEndpoints(address, a1, a1);
+            Assert.AreEqual(0, res);
+
+            // a2 si nereast of address
+            res = _snitch.CompareEndpoints(address, a2, a1);
+            Assert.AreEqual(-1, res);
+        }
+
+
+
+        [Test]
+        public void TestRack()
+        {
+            string adressRack = _snitch.GetRack(_endpoints[0].RpcAddress);
+            string a1Rack = _snitch.GetRack(_endpoints[1].RpcAddress);
+            string a2Rack = _snitch.GetRack(_endpoints[3].RpcAddress);
+
+            Assert.AreEqual(adressRack, a1Rack);
+            Assert.AreNotEqual(adressRack, a2Rack);
+        }
+
+
+        [Test]
+        public void TestSortedByProximity()
+        {
+            Random rand = new Random();
+
+            //shuffle list
+            var res = _snitch.GetSortedListByProximity(_endpoints[0].RpcAddress,
+                _endpoints.Select(endpoint => endpoint.RpcAddress)
+                .OrderBy(endpoint => rand.Next()));
+
+            //check if ordering has been restored by dc & rack
+            //(ip will be randonly distributed within rack/dc groups)
+            for (int i = 0; i < res.Count; i++)
+            {
+                Assert.AreEqual(_endpoints[i].Datacenter, _snitch.GetDatacenter(res[i]));
+                Assert.AreEqual(_endpoints[i].Rack, _snitch.GetRack(res[i]));
+            }
+        }
+    }
+}

--- a/CassandraSharpUnitTests/Snitch/FactoryTest.cs
+++ b/CassandraSharpUnitTests/Snitch/FactoryTest.cs
@@ -47,6 +47,17 @@ namespace CassandraSharpUnitTests.Snitch
             {
                 throw new NotImplementedException();
             }
+
+            public void Update(NotificationKind kind, Peer peer)
+            {
+                throw new NotImplementedException();
+            }
+
+
+            public bool IsPrimaryDatacenter(IPAddress endpoint)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         [Test]
@@ -69,6 +80,13 @@ namespace CassandraSharpUnitTests.Snitch
         {
             IEndpointSnitch snitch = ServiceActivator<Factory>.Create<IEndpointSnitch>("Simple");
             Assert.IsTrue(snitch is SimpleSnitch);
+        }
+
+        [Test]
+        public void TestCreateDiscovery()
+        {
+            IEndpointSnitch snitch = ServiceActivator<Factory>.Create<IEndpointSnitch>("Discovery");
+            Assert.IsTrue(snitch is DiscoverySnitch);
         }
     }
 }


### PR DESCRIPTION
Added a new snitch that uses the xml configuration framework.

It's something that we require on our cassandra deployment for a future enhanchement that will see accurate datacentre failover. We're actually using GossipingPropertyFileSnitch but can live with updating App.Config on the clients as the network topology changes.

Only issue I can see is if discovery adds new nodes to the cluster, the xml properties will be out of date. Currently this throws an exception but since the datacentre and rack are available in system.peers, which is queried on node Discovery, could we add a way to dynamically update a snitch? Maybe add update method to iEndpointSnitch that is initialized in ClusterManager like:

```
 discoveryService.OnTopologyUpdate += snitch.Update;
```

I'm happy to make another push if you agree?
