### PR TITLE
Memory Leak/Deadlock condition with LongRunningConnection

### DIFF
--- a/CassandraSharp/Transport/LongRunningConnection.cs
+++ b/CassandraSharp/Transport/LongRunningConnection.cs
@@ -193,18 +193,15 @@ namespace CassandraSharp.Transport
                     }
                 }
 
-				var pendingQueriesList = _pendingQueries.ToList();
-				_pendingQueries.Clear();
-
-				foreach (var queryInfo in pendingQueriesList)
+				foreach (var queryInfo in _pendingQueries)
 				{
 					queryInfo.NotifyError(canceledException);
 					_instrumentation.ClientTrace(queryInfo.Token, EventType.Cancellation);
 				}
 
-				pendingQueriesList.Clear();
+				_pendingQueries.Clear();
 
-                _isClosed = true;
+				_isClosed = true;
             }
 
             // we have now the guarantee this instance is destroyed once


### PR DESCRIPTION
LongRunningConnection creates two tasks. One for reading a response from cassandra (ReadResponseWorker) and one for sending queries to cassandra (SendQueryWorker).
If there is an exception inside one of the those two methods HandleError is called which in turns calls the Close method. At the end of Close there are two lines of code:

``` c#
ExceptionExtensions.SafeExecute(() => _responseWorker.Wait());
ExceptionExtensions.SafeExecute(() => _queryWorker.Wait());
```

If the exception happened in ReadResponseWorker then the first line will hang because you've essentially created a deadlock situation. The task can't complete because it's calling a method that is issuing a wait on the object that holds the task. This also stops the connection object from being garbage collected. 
