### PR TITLE
Async TCP connection to node, so connection timeout can be set.

### DIFF
--- a/CassandraSharp.Interfaces/Config/TransportConfig.cs
+++ b/CassandraSharp.Interfaces/Config/TransportConfig.cs
@@ -44,6 +44,9 @@ namespace CassandraSharp.Config
         [XmlAttribute("type")]
         public string Type { get; set; }
 
+        [XmlAttribute("connTimeout")]
+        public int ConnectionTimeout { get; set; }
+
         [XmlAttribute("rcvTimeout")]
         public int ReceiveTimeout { get; set; }
 


### PR DESCRIPTION
Hi,

I've made some enhancements on the tcp connections. 
The TcpClient.Connect() method uses a default 20 sec timeout, and .net framework does not expose any field or property to set it. (See issue #64)
I use async connect so we can use a less than 20sec timeout to connect to a node.
