### PR TITLE
Set the default connection timeout >0.

### DIFF
--- a/CassandraSharp.Interfaces/Config/TransportConfig.cs
+++ b/CassandraSharp.Interfaces/Config/TransportConfig.cs
@@ -30,7 +30,7 @@ namespace CassandraSharp.Config
             DefaultExecutionFlags = ExecutionFlags.None;
             KeepAlive = true;
             ReceiveBuffering = true;
-            ConnectionTimeout = 3000;
+            ConnectionTimeout = 0; // zero represents forever, here.
         }
 
         [XmlAttribute("keepAlive")]

--- a/CassandraSharp/Transport/LongRunningConnection.cs
+++ b/CassandraSharp/Transport/LongRunningConnection.cs
@@ -89,8 +89,9 @@ namespace CassandraSharp.Transport
                         LingerState = { Enabled = true, LingerTime = 0 },
                     };
 
+				var ttw = _config.ConnectionTimeout == 0 ? TimeSpan.FromMilliseconds(-1) : TimeSpan.FromSeconds(_config.ConnectionTimeout);
                 IAsyncResult asyncResult = _tcpClient.BeginConnect(address, _config.Port, null, null);
-                bool success = asyncResult.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(_config.ConnectionTimeout), true);
+                bool success = asyncResult.AsyncWaitHandle.WaitOne(ttw, true);
 
                 if (! success)
                 {


### PR DESCRIPTION
The default connection timeout (in TransportConfig.ConnectionTimeout)
was left at zero, which makes it impossible to connect to a server
without setting up an XML configuration block. Setting this to some
value greater than zero makes it work by default.
