### PR TITLE
Fixes issue 82 (DataMapper exception when trying to deserialize value ty...

### DIFF
--- a/CassandraSharp/CQLPoco/DataMapper.cs
+++ b/CassandraSharp/CQLPoco/DataMapper.cs
@@ -68,7 +68,7 @@ namespace CassandraSharp.CQLPoco
 
                 var data = column.RawData != null
                         ? member.ValueSerializer.Deserialize(column.RawData)
-                        : null;
+                        : member.DefaultValue;
 
                 member.SetValue(instance, data);
             }

--- a/CassandraSharp/CQLPoco/MemberMap.cs
+++ b/CassandraSharp/CQLPoco/MemberMap.cs
@@ -40,6 +40,7 @@ namespace CassandraSharp.CQLPoco
 
             ColumnName = GetColumnName(memberInfo);
             ValueSerializer = ValueSerializerProvider.GetSerializer(Type);
+			DefaultValue = Type.IsValueType ? Activator.CreateInstance(Type) : null;
         }
 
         public ClassMap ClassMap { get; private set; }
@@ -82,6 +83,8 @@ namespace CassandraSharp.CQLPoco
         {
             return Activator.CreateInstance(Type);
         }
+
+		public object DefaultValue { get; private set; }
 
         public static bool IsIgnored(MemberInfo mi)
         {


### PR DESCRIPTION
...pes) by using the .Net data type's default value which is cached within the MemberMap object.
